### PR TITLE
Make schedule bee-have like bee-queue process.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -4,15 +4,15 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-githooks');
 
   grunt.initConfig({
-    eslint: {
-      options: {
-        config: '.eslintrc'
-      },
-      target: [
-        'lib/**/*.js',
-        'test/**/*.js'
-      ]
-    },
+		eslint: {
+			options: {
+				config: '.eslintrc'
+			},
+			target: [
+				'lib/**/*.js',
+				'test/**/*.js'
+			]
+		},
     mochaTest: {
       test: {
         options: {
@@ -30,4 +30,5 @@ module.exports = function(grunt) {
 
   grunt.registerTask('default', ['eslint']);
   grunt.registerTask('test', ['eslint', 'mochaTest']);
+  grunt.registerTask('test-only', ['mochaTest']);
 };

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,6 +1,5 @@
 'use strict';
 
-
 class BeeQueueError extends Error {}
 class JobNotFoundBeeQueueError extends BeeQueueError {}
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -14,7 +14,16 @@ var defaultCb = function (err) {
   }
 };
 
+var restartOnError = function(client, tick) {
+	var restart = function() {
+		client.on('ready', tick);
+	};
+	client.on('error', restart);
+	client.on('end', restart);
+};
+
 module.exports = {
   barrier: barrier,
-  defaultCb: defaultCb
+  defaultCb: defaultCb,
+	restartOnError: restartOnError
 };

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -285,23 +285,30 @@ Queue.prototype.finishJob = function (err, data, job, cb) {
   });
 };
 
-Queue.prototype.schedule = function (interval) {
+Queue.prototype.schedule = function (interval, handler) {
   var self = this;
-  var startTime = new Date().getTime();
   interval = interval || 500;
-  self.client.evalsha(lua.shas.checkDelay, 3,
-      self.toKey('schedulelock'),
-      self.toKey('schedule'),
-      self.toKey('waiting'),
-      os.hostname() + ':' + process.pid + this._random,
-      new Date().getTime(),
-      function (err, count) {
-        if (err) return console.error(err);
-        var delay = startTime - new Date().getTime() + interval;
-        if (delay < 1)setImmediate(self.schedule.bind(self), interval);
-        else setTimeout(self.schedule.bind(self), delay, interval);
-      }
-  );
+
+	var tick = function() {
+		var startTime = new Date().getTime();
+		self.client.evalsha(lua.shas.checkDelay, 3,
+				self.toKey('schedulelock'),
+				self.toKey('schedule'),
+				self.toKey('waiting'),
+				os.hostname() + ':' + process.pid + this._random,
+				new Date().getTime(),
+				function (err, count) {
+					if (err) return console.error(err);
+					if (handler) handler(err);
+					var delay = startTime - new Date().getTime() + interval;
+					if (delay < 1) setImmediate(tick);
+					else setTimeout(tick, delay);
+				}
+		);
+	};
+
+	helpers.restartOnError(this.client, tick);
+	setImmediate(tick);
 };
 
 Queue.prototype.process = function (concurrency, handler) {
@@ -362,12 +369,7 @@ Queue.prototype.process = function (concurrency, handler) {
     });
   };
 
-  var restartProcessing = function () {
-    // maybe need to increment queued here?
-    self.bclient.once('ready', jobTick);
-  };
-  this.bclient.on('error', restartProcessing);
-  this.bclient.on('end', restartProcessing);
+	helpers.restartOnError(this.bclient, jobTick);
 
   this.checkStalledJobs(setImmediate.bind(null, jobTick));
 };


### PR DESCRIPTION
Not sure if bee-queue's own internal error handling was doing much, but now our schedule implementation does it too.

I don't believe bee-queue can recover from redis actually going down, it can only recover from temporary disconnects, like what would happen if the server closed the connection when there was no activity. This may be one of the reasons we saw things like UGC photos taking a long time to index ( the scheduler may not have restarted after a temporary disconnect ).
